### PR TITLE
Fixing the link to travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ This booklet describes SUnit and DrTests.
 [travis]:https://travis-ci.com/SquareBracketAssociates/Booklet-TestingInPharo
 [badge]:https://travis-ci.com/SquareBracketAssociates/Booklet-TestingInPharo.svg?branch=master
 
-The result from the latest successful Travis build can be found in the release panel [https://github.com/SquareBracketAssociates/Booklet-ManagingCode/releases](https://github.com/SquareBracketAssociates/Booklet-ManagingCode/releases)
+The result from the latest successful Travis build can be found in the release panel [https://github.com/SquareBracketAssociates/Booklet-TestingInPharo/releases](https://github.com/SquareBracketAssociates/Booklet-TestingInPharo/releases)


### PR DESCRIPTION
The travis link is redirecting to the ManagingCode booklet, it should redirect to the TestingInPharo-Booklet instead.