### PR TITLE
Fix MuTalk chapter reference in index for case-sensitive environments

### DIFF
--- a/index.md
+++ b/index.md
@@ -132,7 +132,7 @@ without fear to break your code and not getting notified about it.
 
 %<!inputFile|path=Chapters/Mocking/StateSpecs.md!>
 
-<!inputFile|path=Chapters/Mutalk/Mutalk.md!>
+<!inputFile|path=Chapters/MuTalk/MuTalk.md!>
 
 <!inputFile|path=Chapters/Benchs/Smark.md!>
 


### PR DESCRIPTION
Changes references to MuTalk chapter in `index.md`. This is required for building on case-sensitive environments, such as the build workflow in this repository. 